### PR TITLE
LocalStorageEmitter fix #3

### DIFF
--- a/LocalStorageEmitter.ts
+++ b/LocalStorageEmitter.ts
@@ -49,7 +49,6 @@ import {ComponentRef} from 'angular2/core';
 
 export function LocalStorageSubscriber(appPromise:Promise<ComponentRef>) {
     appPromise.then((bla) => {
-        console.log('app booted', bla);
-        console.log(bla.injector.resolveAndInstantiate(<Type>LocalStorageService));
+        bla.injector.resolveAndInstantiate(<Type>LocalStorageService);
     });
 }


### PR DESCRIPTION
Targeting the problem reported in #3. Typescript compiles again, uses two arrays to keep track of the ngZone objects and the returned "Subscription" objects. For the ngZone at index i the subscription object is placed at index i in the _subscribed_ array.
