### PR TITLE
Only local dependencies in npm.scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Angular2 decorator to save and restore class properties automatically from LocalStorage.",
   "main": "index.js",
   "scripts": {
-    "lint": "tslint ./*.ts -t verbose",
-    "tsc": "tsc",
-    "postinstall": "typings install",
+    "lint": "./node_modules/.bin/tslint ./*.ts -t verbose",
+    "tsc": "./node_modules/.bin/tsc",
+    "postinstall": "./node_modules/.bin/typings install",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -23,13 +23,16 @@
     "url": "https://github.com/marcj/angular2-localstorage/issues"
   },
   "homepage": "https://github.com/marcj/angular2-localstorage",
+  "dependencies": {
+    "typings": "^1.3.3"
+  },
   "devDependencies": {
     "@angular/core": "^2.0.0",
     "es6-shim": "^0.35.1",
     "reflect-metadata": "0.1.8",
     "rxjs": "5.0.0-beta.12",
     "tslint": "^3.15.1",
-    "typings": "^1.3.3",
+    "typescript": "^2.0.7",
     "zone.js": "0.6.23"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "Angular2 decorator to save and restore class properties automatically from LocalStorage.",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/tslint ./*.ts -t verbose",
-    "tsc": "./node_modules/.bin/tsc",
-    "postinstall": "./node_modules/.bin/typings install",
+    "lint": "tslint ./*.ts -t verbose",
+    "tsc": "tsc",
+    "postinstall": "typings install",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {


### PR DESCRIPTION
I don't want to install globally `typings`, `tsc` and `tslint`
Decision for #35